### PR TITLE
Create a new table to store auth_results

### DIFF
--- a/Solaris/DmarcAggregateParser.php
+++ b/Solaris/DmarcAggregateParser.php
@@ -109,10 +109,10 @@ class DmarcAggregateParser {
 						try {
 							$sth = $this->dbh->prepare( "INSERT INTO rptresult(serial,ip,type,seq,domain,result) VALUES(?, ?, ?, ?, ?, ?)" );
 							$sth->execute( array( $serial, $row->source_ip, $type, $seq, $result->domain, $result->result ) );
-				}
-				catch( PDOException $e ) {
-					$this->errors[] = $e->getMessage();
-				}
+						}
+						catch( PDOException $e ) {
+							$this->errors[] = $e->getMessage();
+						}
 
 						$seq++;
 					}

--- a/tables.sql
+++ b/tables.sql
@@ -17,9 +17,17 @@ CREATE TABLE rptrecord (
   count int(10) unsigned NOT NULL,
   disposition enum('none','quarantine','reject'),
   reason varchar(255),
-  dkim_domain varchar(255),
   dkim_result enum('none','pass','fail','neutral','policy','temperror','permerror'),
-  spf_domain varchar(255),
   spf_result enum('none','neutral','pass','fail','softfail','temperror','permerror'),
   KEY serial (serial,ip)
+);
+
+CREATE TABLE rptresult (
+  serial int(10) unsigned NOT NULL,
+  ip varchar(39) NOT NULL,
+  type enum('dkim','spf'),
+  seq int(10) unsigned NOT NULL,
+  domain varchar(255),
+  result enum('none','pass','fail','neutral','policy','temperror','permerror'),
+  KEY serial (serial,ip,type,seq)
 );


### PR DESCRIPTION
Per our conversation on #3, I've created a new table to house the `auth_results` data and moved it off of `rptrecord`. At the same time I updated `rptrecord.dkim_result` and `rptrecord.spf_result` to use the info from `policy_evaluated`.

Take a look and let me know what you think. It does change the schema by removing the domains from `rptrecord`. If you want to leave those alone as technical debt, we could keep them there but not populate them.