### PR TITLE
Use transactions so a file is never left in a partially loaded state

### DIFF
--- a/Solaris/DmarcAggregateParser.php
+++ b/Solaris/DmarcAggregateParser.php
@@ -39,6 +39,8 @@ class DmarcAggregateParser {
 		if( !is_array( $files ) )
 			$files = array( $files );
 
+		$this->dbh->beginTransaction();
+
 		foreach( $files as $file ) {
 			switch (true) {
 				case strtolower( substr( $file, -4 ) ) === '.zip':
@@ -118,6 +120,12 @@ class DmarcAggregateParser {
 					}
 				}
 			}
+		}
+
+		if (empty($this->errors)) {
+			$this->dbh->commit();
+		} else {
+			$this->dbh->rollBack();
 		}
 
 		return empty( $this->errors );


### PR DESCRIPTION
Currently, if one the inserts to a child records fails, the parent record has to have its data cleared so the file can be reloaded. This is extremely tedious and error prone. Since the project currently assumes MySQL (or similar) is in use, employing transactions should not be a problem.
